### PR TITLE
fix: fixed command info when no docstring is present.

### DIFF
--- a/trogon/widgets/command_info.py
+++ b/trogon/widgets/command_info.py
@@ -90,9 +90,11 @@ class CommandInfo(ModalScreen):
                 tabs.focus()
                 yield tabs
 
-            command_info = self.command_schema.docstring
-            if command_info:
-                command_info = command_info.strip()
+            command_info = (
+                self.command_schema.docstring.strip()
+                if self.command_schema.docstring
+                else "No description available"
+            )
 
             with ContentSwitcher(
                 initial="command-info-text", id="command-info-switcher"


### PR DESCRIPTION
Fixed error on description tab when no docstring is available.