### PR TITLE
Bind escape and q to exit without running anything

### DIFF
--- a/trogon/trogon.py
+++ b/trogon/trogon.py
@@ -47,6 +47,7 @@ class CommandBuilder(Screen):
 
     BINDINGS = [
         Binding(key="ctrl+r", action="close_and_run", description="Close & Run"),
+        Binding("q,escape", "close_no_run", "Close Without Running"),
         Binding(
             key="ctrl+t", action="focus_command_tree", description="Focus Command Tree"
         ),
@@ -132,6 +133,9 @@ class CommandBuilder(Screen):
 
     def action_close_and_run(self) -> None:
         self.app.execute_on_exit = True
+        self.app.exit()
+
+    def action_close_no_run(self) -> None:
         self.app.exit()
 
     def action_about(self) -> None:


### PR DESCRIPTION
This adds a key binding for exiting the TUI via the same key bindings as closing modals.

ISTM perhaps it'd be nicer for `escape` to be bound to work sort of like a back button, so that if you hit it in the right pane of the TUI you "jump outward" back into the left sidebar. But that is obviously more work than just this 3 line change (and seems more subjective). I'm not sure I can commit to figuring out how to wire that in even if interested, but let me know what you folks think.