### PR TITLE
Add Python 3.7 to classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,11 @@ classifiers = [
     "Operating System :: Microsoft :: Windows :: Windows 10",
     "Operating System :: Microsoft :: Windows :: Windows 11",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Documentation",
 ]
 


### PR DESCRIPTION
This is to match python ^3.7 from dependencies in https://github.com/Textualize/trogon/commit/f7adc20d7b9e058b92de0f92a4aaa0356a9fb2fd