### PR TITLE
Fix error of unexpected keyword argument for category and labels

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -45,7 +45,7 @@ def cli(ctx, verbose):
     help="Add labels to the task (repeatable)",
 )
 @click.pass_context
-def add(ctx, task, priority, tags, extra):
+def add(ctx, task, priority, tags, extra, category, labels):
     """Add a new task to the to-do list.
     Note:
     Control the output of this using the verbosity option.
@@ -55,6 +55,8 @@ def add(ctx, task, priority, tags, extra):
         click.echo(f"Priority: {priority}")
         click.echo(f'Tags: {", ".join(tags)}')
         click.echo(f"Extra data: {extra}")
+        click.echo(f"Category: {category}")
+        click.echo(f'Labels: {", ".join(labels)}')
     elif ctx.obj["verbose"] >= 1:
         click.echo(f"Adding task: {task}")
     else:


### PR DESCRIPTION
### Description

When running `cd examples && python3 demo.py tui`, the program throws errors of `TypeError: add() got an unexpected keyword argument 'category'`.

### Why

As suggested by the error messages, 'category' and 'labels` need to be included in the argument parameters.

```txt
❯ python demo.py tui
Running python demo.py add 'hello world'
Traceback (most recent call last):
  File "/Users/tian/Documents/ghpr/trogon/examples/demo.py", line 89, in <module>
    cli(obj={})
  File "/opt/homebrew/Caskroom/miniconda/base/envs/trogon/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/trogon/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/trogon/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/homebrew/Caskroom/miniconda/base/envs/trogon/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/trogon/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/trogon/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
TypeError: add() got an unexpected keyword argument 'category'
```