### PR TITLE
Fix checkbox right padding

### DIFF
--- a/trogon/widgets/form.py
+++ b/trogon/widgets/form.py
@@ -44,7 +44,7 @@ class CommandForm(Widget):
     .command-form-checkbox {
         background: $boost;
         margin: 1 0 0 0;
-        padding-left: 1;
+        padding: 0 1 0 1;
         border: tall transparent;
     }
     .command-form-checkbox:focus {


### PR DESCRIPTION
Before:
<img width="386" alt="image" src="https://github.com/Textualize/trogon/assets/230655/61784896-a4c7-4acc-b789-39eb003e0902">

After:
<img width="399" alt="image" src="https://github.com/Textualize/trogon/assets/230655/2c105a2c-5678-4345-93b3-a0d644ffcdcd">
