### PR TITLE
Add support for click.MultiCommand

### DIFF
--- a/trogon/introspect.py
+++ b/trogon/introspect.py
@@ -165,6 +165,13 @@ def introspect_click_app(app: BaseCommand) -> dict[CommandName, CommandSchema]:
                 cmd_data.subcommands[CommandName(subcmd_name)] = process_command(
                     CommandName(subcmd_name), subcmd_obj, parent=cmd_data
                 )
+        elif isinstance(cmd_obj, click.MultiCommand):
+            for subcmd_name in cmd_obj.list_commands(None):
+                cmd_data.subcommands[CommandName(subcmd_name)] = process_command(
+                    CommandName(subcmd_name),
+                    cmd_obj.get_command(None, subcmd_name),
+                    parent=cmd_data
+                )
 
         return cmd_data
 

--- a/trogon/introspect.py
+++ b/trogon/introspect.py
@@ -12,6 +12,10 @@ def generate_unique_id():
     return f"id_{str(uuid.uuid4())[:8]}"
 
 
+def is_grouped_command(cmd: BaseCommand):
+    return isinstance(cmd, click.Group) or isinstance(cmd, click.MultiCommand)
+
+
 @dataclass
 class MultiValueParamData:
     values: list[tuple[int | float | str]]
@@ -123,7 +127,7 @@ def introspect_click_app(app: BaseCommand) -> dict[CommandName, CommandSchema]:
             arguments=[],
             subcommands={},
             parent=parent,
-            is_group=isinstance(cmd_obj, click.Group),
+            is_group=is_grouped_command(cmd_obj),
         )
 
         for param in cmd_obj.params:

--- a/trogon/trogon.py
+++ b/trogon/trogon.py
@@ -27,7 +27,7 @@ from textual.widgets.tree import TreeNode
 from trogon.detect_run_string import detect_run_string
 from trogon.introspect import (
     introspect_click_app,
-    CommandSchema,
+    CommandSchema, is_grouped_command,
 )
 from trogon.run_command import UserCommandData
 from trogon.widgets.command_info import CommandInfo
@@ -67,8 +67,7 @@ class CommandBuilder(Screen):
         super().__init__(name, id, classes)
         self.command_data = None
         self.cli = cli
-        self.is_grouped_cli = (isinstance(cli, click.Group) or
-                               isinstance(cli, click.MultiCommand))
+        self.is_grouped_cli = is_grouped_command(cli)
         self.command_schemas = introspect_click_app(cli)
         self.click_app_name = click_app_name
         self.command_name = command_name
@@ -226,7 +225,7 @@ class Trogon(App):
         super().__init__()
         self.cli = cli
         self.post_run_command: list[str] = []
-        self.is_grouped_cli = isinstance(cli, click.Group)
+        self.is_grouped_cli = is_grouped_command(cli)
         self.execute_on_exit = False
         if app_name is None and click_context is not None:
             self.app_name = detect_run_string()

--- a/trogon/trogon.py
+++ b/trogon/trogon.py
@@ -27,7 +27,8 @@ from textual.widgets.tree import TreeNode
 from trogon.detect_run_string import detect_run_string
 from trogon.introspect import (
     introspect_click_app,
-    CommandSchema, is_grouped_command,
+    CommandSchema,
+    is_grouped_command,
 )
 from trogon.run_command import UserCommandData
 from trogon.widgets.command_info import CommandInfo

--- a/trogon/trogon.py
+++ b/trogon/trogon.py
@@ -67,7 +67,8 @@ class CommandBuilder(Screen):
         super().__init__(name, id, classes)
         self.command_data = None
         self.cli = cli
-        self.is_grouped_cli = isinstance(cli, click.Group)
+        self.is_grouped_cli = (isinstance(cli, click.Group) or
+                               isinstance(cli, click.MultiCommand))
         self.command_schemas = introspect_click_app(cli)
         self.click_app_name = click_app_name
         self.command_name = command_name


### PR DESCRIPTION
Adds basic support for click's `MultiCommand`s (see #62).

MultiCommands can basically be treated like a `Group`. The only difference is how you iterate over the subcommands.