### PR TITLE
Do not treat Select.BLANK as a supplied value

### DIFF
--- a/trogon/widgets/parameter_controls.py
+++ b/trogon/widgets/parameter_controls.py
@@ -252,7 +252,7 @@ class ParameterControls(Widget):
         if isinstance(control, MultipleChoice):
             return control.selected
         elif isinstance(control, Select):
-            if control.value is None:
+            if control.value is None or control.value is Select.BLANK:
                 return ValueNotSupplied()
             return control.value
         elif isinstance(control, Input):


### PR DESCRIPTION
Optional parameters of type `click.Choice` cannot be used otherwise because `Select.BLANK` was always used as the parameter value instead.