### PR TITLE
Add import to READMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ pip install trogon
 1. Import `from trogon import tui`
 2. Add the `@tui` decorator above your click app. e.g.
     ```python
+    from trogon import tui
+    
     @tui()
     @click.group(...)
     def cli():


### PR DESCRIPTION
It's a minor thing, because it's somewhat obvious, but it feels somewhat nicer to have the required import statement on top of the code cell there. That way folks don't have to guess. 