### PR TITLE
fix crash on Textual 80.0

### DIFF
--- a/trogon/trogon.py
+++ b/trogon/trogon.py
@@ -180,7 +180,7 @@ class CommandBuilder(Screen):
         """Update the description of the command at the bottom of the sidebar
         based on the currently selected node in the command tree."""
         description_box = self.query_one("#home-command-description", Static)
-        description_text = node.data.docstring or ""
+        description_text = "" if node.data is None else node.data.docstring or ""
         description_text = description_text.lstrip()
         description_text = f"[b]{node.label if self.is_grouped_cli else self.click_app_name}[/]\n{description_text}"
         description_box.update(description_text)
@@ -208,12 +208,13 @@ class CommandBuilder(Screen):
 
         # Process the metadata for this command and mount corresponding widgets
         command_schema = node.data
-        command_form = CommandForm(
-            command_schema=command_schema, command_schemas=self.command_schemas
-        )
-        await parent.mount(command_form)
-        if not self.is_grouped_cli:
-            command_form.focus()
+        if command_schema is not None:
+            command_form = CommandForm(
+                command_schema=command_schema, command_schemas=self.command_schemas
+            )
+            await parent.mount(command_form)
+            if not self.is_grouped_cli:
+                command_form.focus()
 
 
 class Trogon(App):

--- a/trogon/widgets/form.py
+++ b/trogon/widgets/form.py
@@ -98,7 +98,7 @@ class CommandForm(Widget):
 
     def compose(self) -> ComposeResult:
         path_from_root = iter(reversed(self.command_schema.path_from_root))
-        command_node = next(path_from_root)
+        command_node = next(path_from_root, None)
         with VerticalScroll() as vs:
             vs.can_focus = False
 


### PR DESCRIPTION
Trogon was crashing when paired with Textual 0.80.0. With the following excepetion...

<img width="2146" alt="Screenshot 2024-09-30 at 19 55 59" src="https://github.com/user-attachments/assets/c0ea6dcb-8f03-443d-a39d-8fa7e74dfbd7">

This change appears to fix it, but as I'm not familiar with this project, I'd appreciate another pair of eyes!

@daneah @darrenburns 