### PR TITLE
Use deferred annotations in typer loader for 3.9

### DIFF
--- a/trogon/typer.py
+++ b/trogon/typer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 
 try:


### PR DESCRIPTION
For Python 3.9 compatibility, the typer loader file needs to use deferred annotations.