### PR TITLE
Make on_mount callback customizable

### DIFF
--- a/examples/change_default_theme.py
+++ b/examples/change_default_theme.py
@@ -1,0 +1,17 @@
+import click
+from textual.app import App
+
+from trogon import tui
+
+
+def on_mount(app: App):
+    app.theme = 'tokyo-night'
+
+@tui(on_mount=on_mount)
+@click.command()
+def hello_world():
+    """Prints 'Hello world'."""
+    click.echo('Hello world.')
+
+if __name__ == "__main__":
+    hello_world()


### PR DESCRIPTION
Introduce the ability to customize the `on_mount` callback of the underlying Textual App. By allowing users to specify the `on_mount` behavior, they can define their own logic for the application's mount phase. For example, users can change the default theme of the generated Trogon app.

## Example
```
def on_mount(app: App):
    app.theme = 'tokyo-night'

@tui(on_mount=on_mount)
@click.command()
def hello_world():
    """Prints 'Hello world'."""
    click.echo('Hello world.')
```


I wasn't entirely sure if this behavior could be achieved in a different way, so I implemented it using the `on_mount` callback. However, I'm open to adjust the implementation if there's a more idiomatic or better approach to achieve the same result.
