### PR TITLE
Support dynamic default values

### DIFF
--- a/trogon/widgets/parameter_controls.py
+++ b/trogon/widgets/parameter_controls.py
@@ -157,7 +157,10 @@ class ParameterControls(Widget):
                         for default_value, control_widget in zip(
                             default_value_tuple, widget_group
                         ):
-                            self._apply_default_value(control_widget, default_value)
+                            if isinstance(default_value, Callable):
+                                self._apply_default_value(control_widget, default_value())
+                            else:
+                                self._apply_default_value(control_widget, default_value)
                             yield control_widget
                             # Keep track of the first control we render, for easy focus
                             if first_focus_control is None:


### PR DESCRIPTION
Typer allows passing a `default_factory` to options and arguments, which is a callable that will be used at runtime to determine the default value. [Typer sets the option's `default` on the Click command object to the supplied factory value](https://github.com/fastapi/typer/blob/46f4a0f470400aef45fd3d433c5066687f4d61e8/typer/utils.py#L180).

The Textual application created by Trogon crashes when this is used, because it tries to convert the str representation of the callable function for display when it should be converting the result of calling that function instead.

I don't think I fully understand why this crash occurs, since it appears that Trogon properly handles a default Click application when an option's default is e.g. a `lambda`. Perhaps Typer is missing something in its translation of `default_factory` to Click's `default`, and I'm open to filing an issue/opening a PR on their end if it appears that's the case, but I'd need help in better understanding it!